### PR TITLE
Now shortening by original url length, not escaped url length.

### DIFF
--- a/addon/helpers/linkify.js
+++ b/addon/helpers/linkify.js
@@ -7,11 +7,11 @@ import { urlRegex , shortenUrl } from 'ember-linkify/utils/url-regex';
 const ALLOWED_ATTRIBUTE_NAMES = [ 'rel', 'class' ];
 
 export function linkify( params, options ) {
-  let textToLinkify      = Ember.Handlebars.Utils.escapeExpression(params[0]);
-  const windowTarget     = params[1] || "_self";
-  const sharedAttributes = opts2attrs( options );
+  let textToLinkifyOriginal = params[0];
+  const windowTarget        = params[1] || "_self";
+  const sharedAttributes    = opts2attrs( options );
 
-  textToLinkify = textToLinkify.replace(urlRegex(), function (s) {
+  let textToLinkify = textToLinkifyOriginal.replace(urlRegex(), function (s) {
     let url;
     let displayText = s.trim();
 
@@ -29,8 +29,18 @@ export function linkify( params, options ) {
       displayText = shortenUrl( displayText, options.urlLength );
     }
 
+    // make the url and display text html friendly
+    url = Ember.Handlebars.Utils.escapeExpression(url);
+    displayText = Ember.Handlebars.Utils.escapeExpression(displayText)
+
     return `<a href="${url}" target="${windowTarget}"${sharedAttributes}>${displayText}</a>`;
   });
+
+  // if no urls were found, then we escape the entire input, this prevents things like <script> from being
+  // injected
+  if (textToLinkifyOriginal === textToLinkify) {
+    textToLinkify = Ember.Handlebars.Utils.escapeExpression(textToLinkifyOriginal);
+  }
 
   return htmlSafe(textToLinkify);
 }

--- a/tests/unit/helpers/linkify-test.js
+++ b/tests/unit/helpers/linkify-test.js
@@ -1,6 +1,7 @@
 import {
   linkify
 } from 'ember-linkify/helpers/linkify';
+import Ember from 'ember';
 import { module, test } from 'qunit';
 
 module('Unit | Helper | linkify');
@@ -66,6 +67,15 @@ test('it should use the default scheme when no scheme is specified', function(as
   const options = { defaultScheme: 'http' };
   const result = linkify([string], options).toString().trim();
   assert.equal(result, 'This link is missing a scheme: <a href="http://www.foo.com" target="_self">www.foo.com</a>');
+});
+
+test('it should truncate url with query string', function(assert) {
+  const originalUrl = 'https://www.google.com/search?q=ember+linkify&oq=ember+linkify&aqs=chrome..69i57j69i60l3j0.7689j0j4&sourceid=chrome&ie=UTF-8'
+  const expectedText = Ember.Handlebars.Utils.escapeExpression(originalUrl.slice(0,50));
+  const result = linkify([originalUrl], {
+    urlLength: 50
+  }).toString().trim();
+  assert.equal(result, `<a href="${Ember.Handlebars.Utils.escapeExpression(originalUrl)}" target="_self">${expectedText}...</a>`);
 });
 
 test('default scheme should not override an existing scheme', function(assert) {


### PR DESCRIPTION
Previously, the truncated url from the url shortener would shortened by escaped url string, which adds characters for every character it needs to escape, for example:

the character `&` becomes `&amp;`

so some url like:
```
https://www.google.com/search?q=ember+linkify&oq=ember+li&aqs=chrome.0.69i59j69i60l3j0j69i57.3490j0j4&sourceid=chrome&ie=UTF-8
```

when truncated to 50, would become:
```
 https://www.google.com/search?q=ember+linkify...
```

which has 45 characters not including the `...`


now escaping the string after truncation